### PR TITLE
Replace HAPI image

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,8 +2,7 @@
 version: "3.4"
 services:
   hapi:
-    image:
-      "uwcirg/hapi-fhir-oauth2-starter:${DOCKER_IMAGE_TAG:-latest}"
+    image: "hapiproject/hapi:${HAPI_IMAGE_TAG:-v5.5.1}"
     depends_on:
       - db
     ports:


### PR DESCRIPTION
Replace homegrown HAPI image with [community supported one](https://hub.docker.com/r/hapiproject/hapi). Default to HAPI version `v5.5.1`