### PR TITLE
Fixup Postgresql Config

### DIFF
--- a/dev/config/hapi/application.yaml
+++ b/dev/config/hapi/application.yaml
@@ -1,20 +1,8 @@
 spring:
-  datasource:
-    url: 'jdbc:h2:file:./target/database/h2'
-    #url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
-    max-active: 15
-
-    # database connection pool size
-    hikari:
-      maximum-pool-size: 10
   jpa:
     properties:
       hibernate.format_sql: false
       hibernate.show_sql: false
-#      hibernate.dialect: org.hibernate.dialect.h2dialect
 #      hibernate.hbm2ddl.auto: update
 #      hibernate.jdbc.batch_size: 20
 #      hibernate.cache.use_query_cache: false

--- a/dev/default.env
+++ b/dev/default.env
@@ -1,0 +1,17 @@
+# .env example file; copy to .env and modify as necessary
+# Default docker-compose environment file (.env)
+# https://docs.docker.com/compose/environment-variables/#the-env-file
+# environmental variables for interpolation in docker-compose YAML files
+
+# https://docs.docker.com/compose/reference/envvars/#compose_project_name
+# Containers started with the below value will have their names prefixed with it
+# Required on shared infrastructure
+# COMPOSE_PROJECT_NAME=cnics-fhir-dev
+
+# Overrides for ports services listen on
+# EXTERNAL_PORT=
+# PSQL_EXTERNAL_PORT=
+
+# docker image tag overrides; override default image tag with given image tag
+# FHIR_IMAGE_TAG=override-tag-name
+# POSTGRES_IMAGE_TAG=override-tag-name

--- a/dev/default.env
+++ b/dev/default.env
@@ -15,3 +15,9 @@
 # docker image tag overrides; override default image tag with given image tag
 # FHIR_IMAGE_TAG=override-tag-name
 # POSTGRES_IMAGE_TAG=override-tag-name
+
+# docker-compose development overrides; uncomment to enable
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.carl.yaml
+
+# uncomment & modify if using above development overrides
+# CARL_CHECKOUT_DIR=

--- a/dev/default.env
+++ b/dev/default.env
@@ -3,6 +3,8 @@
 # https://docs.docker.com/compose/environment-variables/#the-env-file
 # environmental variables for interpolation in docker-compose YAML files
 
+# BASE_DOMAIN=localtest.me
+
 # https://docs.docker.com/compose/reference/envvars/#compose_project_name
 # Containers started with the below value will have their names prefixed with it
 # Required on shared infrastructure
@@ -15,6 +17,9 @@
 # docker image tag overrides; override default image tag with given image tag
 # FHIR_IMAGE_TAG=override-tag-name
 # POSTGRES_IMAGE_TAG=override-tag-name
+
+# Uncomment for deploys with traefik-managed ingress
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.ingress.yaml
 
 # docker-compose development overrides; uncomment to enable
 # COMPOSE_FILE=docker-compose.yaml:docker-compose.dev.carl.yaml

--- a/dev/docker-compose.dev.carl.yaml
+++ b/dev/docker-compose.dev.carl.yaml
@@ -1,0 +1,11 @@
+# docker-compose development override for carl service
+---
+version: "3.4"
+services:
+  carl:
+    command: sh -c "flask run --host 0.0.0.0 --port ${PORT:-8000}"
+    environment:
+      FLASK_ENV: development
+    volumes:
+    # set in .env
+      - "${CARL_CHECKOUT_DIR}/:/opt/app"

--- a/dev/docker-compose.ingress.yaml
+++ b/dev/docker-compose.ingress.yaml
@@ -1,0 +1,19 @@
+---
+version: "3.4"
+services:
+  fhir:
+    # expose HAPI to internet
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir.${BASE_DOMAIN:-localtest.me}`)"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls=true"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
+    networks:
+      - ingress
+
+networks:
+  # ingress network
+  ingress:
+    external: true
+    name: external_web

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -5,6 +5,12 @@ services:
     image: "hapiproject/hapi:${FHIR_IMAGE_TAG:-v5.5.1}"
     environment:
       SPRING_CONFIG_LOCATION: 'file:///opt/application.yaml'
+      spring.datasource.url: jdbc:postgresql://db:5432/hapifhir
+      spring.datasource.username: hapifhir
+      spring.datasource.password: hapifhir
+      spring.datasource.driverClassName: org.postgresql.Driver
+      spring.jpa.hibernate.dialect: org.hibernate.dialect.PostgreSQL94Dialect
+
     volumes:
       - "./config/hapi/application.yaml:/opt/application.yaml:ro"
     depends_on:

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,7 +2,7 @@
 version: "3.4"
 services:
   fhir:
-    image: "hapiproject/hapi:${HAPI_IMAGE_TAG:-v5.5.1}"
+    image: "hapiproject/hapi:${FHIR_IMAGE_TAG:-v5.5.1}"
     environment:
       SPRING_CONFIG_LOCATION: 'file:///opt/application.yaml'
     volumes:
@@ -13,7 +13,7 @@ services:
       - "127.0.0.1:${EXTERNAL_PORT:-8090}:8080"
 
   db:
-    image: postgres:${POSTGRES_VERSION:-12}
+    image: postgres:${POSTGRES_IMAGE_TAG:-12}
     environment:
       POSTGRES_DB: hapifhir
       POSTGRES_USER: hapifhir

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -2,9 +2,9 @@
 version: "3.4"
 services:
   fhir:
-    image: "hapiproject/hapi:${FHIR_IMAGE_TAG:-v5.5.1}"
+    image: hapiproject/hapi:${FHIR_IMAGE_TAG:-v5.5.1}
     environment:
-      SPRING_CONFIG_LOCATION: 'file:///opt/application.yaml'
+      SPRING_CONFIG_LOCATION: file:///opt/application.yaml
       spring.datasource.url: jdbc:postgresql://db:5432/hapifhir
       spring.datasource.username: hapifhir
       spring.datasource.password: hapifhir

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -1,7 +1,7 @@
 ---
 version: "3.4"
 services:
-  hapi:
+  fhir:
     image: "hapiproject/hapi:${HAPI_IMAGE_TAG:-v5.5.1}"
     environment:
       JAVA_OPTIONS: "--spring.config.location=file:///opt/application.yaml"

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       - db
     ports:
       - "127.0.0.1:${EXTERNAL_PORT:-8090}:8080"
+    networks:
+      - internal
 
   db:
     image: postgres:${POSTGRES_IMAGE_TAG:-12}
@@ -32,6 +34,8 @@ services:
       - "127.0.0.1:${PSQL_EXTERNAL_PORT:-15432}:5432"
     expose:
       - "5432"
+    networks:
+      - internal
 
   carl:
     image: ghcr.io/uwcirg/carl:${CARL_IMAGE_TAG:-latest}
@@ -39,6 +43,12 @@ services:
       FHIR_SERVER_URL: "http://hapi:8080/hapi-fhir-jpaserver/fhir"
     ports:
       - "127.0.0.1:${EXTERNAL_PORT:-5000}:5000"
+    networks:
+      - internal
+
+networks:
+  # internal network for backing services
+  internal:
 
 volumes:
     postgres-data: {}

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   fhir:
     image: "hapiproject/hapi:${HAPI_IMAGE_TAG:-v5.5.1}"
     environment:
-      JAVA_OPTIONS: "--spring.config.location=file:///opt/application.yaml"
+      SPRING_CONFIG_LOCATION: 'file:///opt/application.yaml'
     volumes:
       - "./config/hapi/application.yaml:/opt/application.yaml:ro"
     depends_on:


### PR DESCRIPTION
- Rename `hapi` service to `fhir`
- Configure HAPI with postgres using environment variables (default is H2)
- Add `.env` example file, `default.env`
- Move postgres service to explicit internal network
- Add dev override (see #6)
- Add override for traefik (see #5)