### PR TITLE
Add override for traefik ingress

### DIFF
--- a/dev/default.env
+++ b/dev/default.env
@@ -3,6 +3,8 @@
 # https://docs.docker.com/compose/environment-variables/#the-env-file
 # environmental variables for interpolation in docker-compose YAML files
 
+# BASE_DOMAIN=localtest.me
+
 # https://docs.docker.com/compose/reference/envvars/#compose_project_name
 # Containers started with the below value will have their names prefixed with it
 # Required on shared infrastructure
@@ -15,3 +17,6 @@
 # docker image tag overrides; override default image tag with given image tag
 # FHIR_IMAGE_TAG=override-tag-name
 # POSTGRES_IMAGE_TAG=override-tag-name
+
+# Uncomment for deploys with traefik-managed ingress
+# COMPOSE_FILE=docker-compose.yaml:docker-compose.ingress.yaml

--- a/dev/docker-compose.ingress.yaml
+++ b/dev/docker-compose.ingress.yaml
@@ -1,0 +1,19 @@
+---
+version: "3.4"
+services:
+  fhir:
+    # expose HAPI to internet
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir.${BASE_DOMAIN:-localtest.me}`)"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.entrypoints=websecure"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls=true"
+      - "traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt"
+    networks:
+      - ingress
+
+networks:
+  # ingress network
+  ingress:
+    external: true
+    name: external_web


### PR DESCRIPTION
Enable override and configure `BASE_DOMAIN` to access HAPI via `fhir.$BASE_DOMAIN`