### PR TITLE
Can't use same EXTERNAL_PORT for two services

### DIFF
--- a/dev/default.env
+++ b/dev/default.env
@@ -12,6 +12,7 @@
 
 # Overrides for ports services listen on
 # EXTERNAL_PORT=
+# FHIR_EXTERNAL_PORT=
 # PSQL_EXTERNAL_PORT=
 
 # docker image tag overrides; override default image tag with given image tag

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - db
     ports:
-      - "127.0.0.1:${EXTERNAL_PORT:-8090}:8080"
+      - "127.0.0.1:${FHIR_EXTERNAL_PORT:-8090}:8080"
     networks:
       - internal
 


### PR DESCRIPTION
create unique variable name for each `EXTERNAL_PORT`

without this change, `dc up -d` always generates an error regardless of `EXTERNAL_PORT` value when the second service attempts to bind to a port which has been claimed by the first service started.